### PR TITLE
Refactor: Centralize permission handling

### DIFF
--- a/app/src/main/java/com/hereliesaz/blusnu/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/MainActivity.kt
@@ -87,11 +87,14 @@ import com.hereliesaz.blusnu.ui.reporting.ReportingViewModel
 import com.hereliesaz.blusnu.ui.settings.SettingsScreen
 import com.hereliesaz.blusnu.ui.settings.SettingsViewModel
 import com.hereliesaz.blusnu.ui.theme.BluSnuTheme
-
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 
 class MainActivity : ComponentActivity() {
 
+    private val _hasPermissions = MutableStateFlow(false)
+    val hasPermissions: StateFlow<Boolean> = _hasPermissions
     private val deviceRepository by lazy { DeviceRepository() }
     private val hardwareManager by lazy { HardwareManager() }
     private val btlejuiceModule by lazy { BtlejuiceModule(hardwareManager) }
@@ -152,9 +155,7 @@ class MainActivity : ComponentActivity() {
 
     private val requestPermissionsLauncher =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            permissions.entries.forEach {
-                // Log or handle individual permission results
-            }
+            _hasPermissions.value = permissions.values.all { it }
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -166,6 +167,8 @@ class MainActivity : ComponentActivity() {
         requestRequiredPermissions()
 
         setContent {
+            val hasPermissions by hasPermissions.collectAsState()
+
             BluSnuTheme {
                 var showDisclaimer by remember { mutableStateOf(!getSharedPreferences("blusnu_prefs", Context.MODE_PRIVATE).getBoolean("disclaimer_accepted", false)) }
 
@@ -221,7 +224,7 @@ class MainActivity : ComponentActivity() {
                                 }
                                 composable("targets") {
                                     val viewModel: TargetManagementViewModel = viewModel(factory = viewModelFactory)
-                                    TargetManagementScreen(viewModel = viewModel, navController = navController)
+                                    TargetManagementScreen(viewModel = viewModel, navController = navController, hasPermissions = hasPermissions)
                                 }
                                 composable("settings") { SettingsScreen() }
                                 composable("bluebugging") {
@@ -230,11 +233,11 @@ class MainActivity : ComponentActivity() {
                                 }
                                 composable("bluesnarfing") {
                                     val viewModel: BluesnarfingViewModel = viewModel(factory = viewModelFactory)
-                                    com.hereliesaz.blusnu.ui.bluesnarfing.BluesnarfingScreen(viewModel = viewModel, hasPermissions = true)
+                                    com.hereliesaz.blusnu.ui.bluesnarfing.BluesnarfingScreen(viewModel = viewModel, hasPermissions = hasPermissions)
                                 }
                                 composable("btlejacking") {
                                     val viewModel: BtlejackingViewModel = viewModel(factory = viewModelFactory)
-                                    BtlejackingScreen(viewModel = viewModel, hasPermissions = !showDisclaimer)
+                                    BtlejackingScreen(viewModel = viewModel, hasPermissions = hasPermissions)
                                 }
                                 composable(
                                     "btlejuice/{targetDevice}",

--- a/app/src/main/java/com/hereliesaz/blusnu/ui/TargetManagementScreen.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/ui/TargetManagementScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,8 +45,18 @@ import androidx.compose.material3.MaterialTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TargetManagementScreen(modifier: Modifier = Modifier, viewModel: TargetManagementViewModel, navController: NavController) {
+fun TargetManagementScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TargetManagementViewModel,
+    navController: NavController,
+    hasPermissions: Boolean
+) {
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(hasPermissions) {
+        viewModel.onPermissionsResult(hasPermissions)
+    }
+
     var textFilter by remember { mutableStateOf("") }
     var filterType by remember { mutableStateOf<FilterType>(FilterType.Text) }
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp

--- a/app/src/main/java/com/hereliesaz/blusnu/ui/TargetManagementViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/ui/TargetManagementViewModel.kt
@@ -91,30 +91,18 @@ class TargetManagementViewModel(
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TargetManagementScreenState())
 
-        updatePermissionsState()
         updateBluetoothState()
-    }
-
-    private fun updatePermissionsState() {
-        val hasPermissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
-                getApplication(),
-                Manifest.permission.BLUETOOTH_SCAN
-            ) == PackageManager.PERMISSION_GRANTED && ContextCompat.checkSelfPermission(
-                getApplication(),
-                Manifest.permission.BLUETOOTH_CONNECT
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            ContextCompat.checkSelfPermission(
-                getApplication(),
-                Manifest.permission.ACCESS_FINE_LOCATION
-            ) == PackageManager.PERMISSION_GRANTED
-        }
-        _state.update { it.copy(hasPermissions = hasPermissions) }
     }
 
     private fun updateBluetoothState() {
         _state.update { it.copy(isBluetoothEnabled = bluetoothAdapter?.isEnabled == true) }
+    }
+
+    fun onPermissionsResult(hasPermissions: Boolean) {
+        _state.update { it.copy(hasPermissions = hasPermissions) }
+        if (hasPermissions) {
+            startScan()
+        }
     }
 
     fun addFilter(filterType: FilterType, value: Any) {

--- a/app/src/main/java/com/hereliesaz/blusnu/ui/bluesnarfing/BluesnarfingScreen.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/ui/bluesnarfing/BluesnarfingScreen.kt
@@ -18,12 +18,18 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
+import androidx.compose.runtime.LaunchedEffect
+
 @Composable
 fun BluesnarfingScreen(viewModel: BluesnarfingViewModel, hasPermissions: Boolean) {
     val macAddress by viewModel.macAddress.collectAsState()
     val status by viewModel.status.collectAsState()
     val result by viewModel.result.collectAsState()
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+
+    LaunchedEffect(hasPermissions) {
+        viewModel.onPermissionsResult(hasPermissions)
+    }
 
     Box(
         modifier = Modifier
@@ -38,7 +44,7 @@ fun BluesnarfingScreen(viewModel: BluesnarfingViewModel, hasPermissions: Boolean
             label = { Text("Target MAC Address") }
         )
         Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = { viewModel.startAttack(hasPermissions) }) {
+        Button(onClick = { viewModel.startAttack() }) {
             Text("Start Attack")
         }
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/hereliesaz/blusnu/ui/bluesnarfing/BluesnarfingViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/ui/bluesnarfing/BluesnarfingViewModel.kt
@@ -27,11 +27,17 @@ class BluesnarfingViewModel(application: Application) : AndroidViewModel(applica
     private val bluesnarfingModule = BluesnarfingModule()
     private val bluetoothAdapter: BluetoothAdapter? = (application.getSystemService(BluetoothManager::class.java) as BluetoothManager).adapter
 
+    private var hasPermissions = false
+
+    fun onPermissionsResult(hasPermissions: Boolean) {
+        this.hasPermissions = hasPermissions
+    }
+
     fun onMacAddressChanged(macAddress: String) {
         _macAddress.value = macAddress
     }
 
-    fun startAttack(hasPermissions: Boolean) {
+    fun startAttack() {
         if (!hasPermissions) {
             _status.value = "Bluetooth connect permission is required"
             return

--- a/app/src/main/java/com/hereliesaz/blusnu/ui/keystrokeinjection/KeystrokeInjectionScreen.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/ui/keystrokeinjection/KeystrokeInjectionScreen.kt
@@ -83,4 +83,5 @@ fun KeystrokeInjectionScreen(
             }
         }
     }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Centralizes the app's permission handling logic within `MainActivity`.

- Introduces a `StateFlow` in `MainActivity` to act as a single source of truth for the permission status.
- The `registerForActivityResult` launcher now updates this `StateFlow`.
- The permission state is collected in the `setContent` block and passed down to the relevant composables (`TargetManagementScreen`, `BluesnarfingScreen`).
- ViewModels (`TargetManagementViewModel`, `BluesnarfingViewModel`) have been refactored to receive permission updates from the UI layer, removing their internal permission-checking logic.
- This resolves inconsistencies and ensures that all parts of the UI have an accurate and reactive view of the permission status.

## Summary by Sourcery

Centralize the app’s permission handling by moving all permission state management to MainActivity and propagating it through the UI, while simplifying ViewModels and updating the build wrapper settings.

Enhancements:
- Use a single StateFlow in MainActivity as the source of truth for permission status
- Pass permission state from MainActivity into composables and notify ViewModels via a callback
- Remove internal permission-checking code from TargetManagementViewModel and BluesnarfingViewModel
- Refactor composable screens to reactively update ViewModels when permission state changes

Build:
- Extend Gradle wrapper configuration with networkTimeout and validateDistributionUrl settings