### PR TITLE
feat: Add missing package attribute to AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.hereliesaz.blusnu"
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />


### PR DESCRIPTION
The AndroidManifest.xml file was missing the `package` attribute, which caused the build to fail. This change adds the `package` attribute with the correct package name, `com.hereliesaz.blusnu`, which resolves the build error.

Additionally, this change includes the regeneration of the Gradle wrapper and the creation of the `local.properties` file to ensure a consistent and reproducible build environment.

## Summary by Sourcery

New Features:
- Declare the Android application package name com.hereliesaz.blusnu in the manifest to properly identify the app bundle.